### PR TITLE
Check if first value in split is empty

### DIFF
--- a/src/kraken-interactions/node.ts
+++ b/src/kraken-interactions/node.ts
@@ -490,7 +490,11 @@ export const stripProtoUrl = (url: string) => {
 }
 
 export const getStateUrlLevels = (url: string): string[] => {
-  return url.split(/[/,_]+/)
+  let split: string[] | undefined = url.split(/[/,_]+/)
+  if (split.length > 1 && split[0] === '') {
+    split.shift()
+  }
+  return split
 }
 
 // Sends a PUT command to set data for a node (Used for power off and power on)

--- a/src/kraken-interactions/node.ts
+++ b/src/kraken-interactions/node.ts
@@ -490,7 +490,7 @@ export const stripProtoUrl = (url: string) => {
 }
 
 export const getStateUrlLevels = (url: string): string[] => {
-  let split: string[] | undefined = url.split(/[/,_]+/)
+  const split = url.split(/[/,_]+/)
   if (split.length > 1 && split[0] === '') {
     split.shift()
   }


### PR DESCRIPTION
Simple fix to check if extension starts with a leading slash.