### PR TITLE
Wait to render graph until user has clicked on the graph button

### DIFF
--- a/src/components/header/styles/header.css
+++ b/src/components/header/styles/header.css
@@ -151,10 +151,11 @@
 
 #color-settings-button {
   margin: 0 15px 5px 15px;
-  padding: 5px;
+  padding-top: 5px;
+  padding-bottom: 3px;
   font-size: 1rem;
   font-weight: bold;
-  color: var(--dark-grey)
+  color: var(--dark-grey);
 }
 
 #ip-apply-button{
@@ -162,8 +163,10 @@
   display: inline-block;
   margin: 0 0 4px 0;
   font-size: 1rem;
-  padding: 1px 20px;
+  padding: 2px 20px 1px 20px;
   top:0;
+  color: var(--dark-grey);
+  font-weight: bold;
 }
 
 .ip-field{

--- a/src/components/nodeview/NodeGraph.tsx
+++ b/src/components/nodeview/NodeGraph.tsx
@@ -11,16 +11,18 @@ interface NodeGraphProps {
 
 interface NodeGraphState {
   data: any
-  options: any
+  settingsMenu: boolean
 }
 
 export class NodeGraph extends Component<NodeGraphProps, NodeGraphState> {
   appRef: RefObject<any> | undefined = undefined
+  configRef: RefObject<any> | undefined = undefined
 
   constructor(props: NodeGraphProps) {
     super(props)
 
     this.appRef = createRef()
+    this.configRef = createRef()
 
     const nodes = props.graph.nodes
 
@@ -39,39 +41,53 @@ export class NodeGraph extends Component<NodeGraphProps, NodeGraphState> {
       edges: new vis.DataSet(props.graph.edges),
     }
 
-    const options = {
-      edges: {
-        arrows: {
-          to: {
-            enabled: true,
-            scaleFactor: 1.5,
-          },
-        },
-        color: {
-          inherit: false,
-        },
-        width: 4,
-      },
-      physics: {
-        enabled: true,
-        barnesHut: {
-          gravitationalConstant: -50000,
-        },
-      },
-      height: '100%',
-      width: '100%',
-    }
-
     this.state = {
       data: data,
-      options: options,
+      settingsMenu: false,
     }
   }
 
   componentDidMount() {
-    if (this.appRef !== undefined) {
-      const network = new vis.Network(this.appRef.current, this.state.data, this.state.options)
-      network.fit(this.state.options)
+    if (this.appRef !== undefined && this.configRef !== undefined) {
+      const options: any = {
+        edges: {
+          arrows: {
+            to: {
+              enabled: true,
+              scaleFactor: 1.5,
+            },
+          },
+          color: {
+            inherit: false,
+          },
+          width: 4,
+        },
+        physics: {
+          enabled: true,
+          barnesHut: {
+            gravitationalConstant: -50000,
+          },
+        },
+        height: '100%',
+        width: '100%',
+        configure: {
+          filter: (option: any, path: any) => {
+            if (path.indexOf('physics') !== -1) {
+              return true
+            }
+            if (path.indexOf('smooth') !== -1 || option === 'smooth') {
+              return true
+            }
+            return false
+          },
+          container: this.configRef.current,
+        },
+      }
+
+      const network = new vis.Network(this.appRef.current, this.state.data, options)
+      network.fit(options)
+    } else {
+      console.log('graph: ', this.appRef, 'config: ', this.configRef)
     }
   }
 
@@ -96,6 +112,12 @@ export class NodeGraph extends Component<NodeGraphProps, NodeGraphState> {
     }
   }
 
+  toggleSettings = () => {
+    this.setState({
+      settingsMenu: !this.state.settingsMenu,
+    })
+  }
+
   render() {
     return (
       <div className={`graph-area`}>
@@ -112,9 +134,15 @@ export class NodeGraph extends Component<NodeGraphProps, NodeGraphState> {
             />
           </svg>
         </div>
+        <button style={{ position: 'absolute', top: 5, zIndex: 10, left: 25 }} onClick={this.toggleSettings}>
+          settings
+        </button>
         <div className={`node-graph`} ref={this.appRef} />
-        {/* <div
-          ref={this.configRef} /> */}
+        <div
+          style={this.state.settingsMenu ? { display: 'block' } : { display: 'none' }}
+          className={`graph-settings`}
+          ref={this.configRef}
+        />
       </div>
     )
   }

--- a/src/components/nodeview/NodeGraph.tsx
+++ b/src/components/nodeview/NodeGraph.tsx
@@ -5,7 +5,6 @@ import { COLORS } from '../../config'
 import CSS from 'csstype'
 
 interface NodeGraphProps {
-  graphOpen: boolean
   graphToggle: () => void
   graph: Graph
 }
@@ -13,7 +12,6 @@ interface NodeGraphProps {
 interface NodeGraphState {
   data: any
   options: any
-  style: CSS.Properties
 }
 
 export class NodeGraph extends Component<NodeGraphProps, NodeGraphState> {
@@ -67,10 +65,6 @@ export class NodeGraph extends Component<NodeGraphProps, NodeGraphState> {
     this.state = {
       data: data,
       options: options,
-      style: {
-        opacity: this.props.graphOpen ? 100 : 0,
-        visibility: this.props.graphOpen ? 'visible' : 'hidden',
-      },
     }
   }
 
@@ -82,15 +76,6 @@ export class NodeGraph extends Component<NodeGraphProps, NodeGraphState> {
   }
 
   componentDidUpdate(prevProps: NodeGraphProps) {
-    if (this.props.graphOpen !== prevProps.graphOpen) {
-      this.setState({
-        style: {
-          opacity: this.props.graphOpen ? 100 : 0,
-          visibility: this.props.graphOpen ? 'visible' : 'hidden',
-        },
-      })
-    }
-
     if (this.props.graph !== prevProps.graph) {
       const data = this.state.data
       const nodes = this.props.graph.nodes
@@ -113,7 +98,7 @@ export class NodeGraph extends Component<NodeGraphProps, NodeGraphState> {
 
   render() {
     return (
-      <div style={this.state.style} className={`graph-area`}>
+      <div className={`graph-area`}>
         <div
           className='close-button'
           onClick={() => {

--- a/src/components/nodeview/NodeView.tsx
+++ b/src/components/nodeview/NodeView.tsx
@@ -62,8 +62,8 @@ export class NodeView extends Component<NodeViewProps, NodeViewState> {
                 graphToggle={this.graphToggle}
               />
             </div>
-            {this.props.graph !== undefined && Object.keys(this.props.graph).length !== 0 && (
-              <NodeGraph graph={this.props.graph} graphOpen={this.state.graphOpen} graphToggle={this.graphToggle} />
+            {this.props.graph !== undefined && Object.keys(this.props.graph).length !== 0 && this.state.graphOpen && (
+              <NodeGraph graph={this.props.graph} graphToggle={this.graphToggle} />
             )}
           </React.Fragment>
         )}

--- a/src/components/nodeview/styles/nodegraph.css
+++ b/src/components/nodeview/styles/nodegraph.css
@@ -1,4 +1,4 @@
-.node-graph{
+.node-graph {
   display: block;
   width: auto;
   height: 100%;
@@ -6,7 +6,7 @@
   border-radius: 8px;
 }
 
-.graph-area{
+.graph-area {
   transition: all 0.1s ease-out;
   position: fixed;
   left: 2rem;
@@ -21,7 +21,7 @@
   border-radius: 10px;
 }
 
-.close-button{
+.close-button {
   z-index: 101;
   position: absolute;
   top: -16px;
@@ -33,4 +33,10 @@
   border: medium solid var(--border-grey);
   border-radius: 50px;
   cursor: pointer;
+}
+
+.graph-settings {
+  position: absolute;
+  top: 0;
+  right: 0;
 }


### PR DESCRIPTION
Before this PR, the graph would start rendering when the user went to the node details page. This change prevents the graph from rendering until the user has clicked the graph button. This is to prevent the application from locking up if the graph is crazy big. 

This PR also adds a settings button to the app to allow the user to adjust the physics settings for the graph.